### PR TITLE
fix: add missing crypto import used for randomUUID

### DIFF
--- a/src/structures/client.ts
+++ b/src/structures/client.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { EventEmitter } from "./eventEmitter";
 import { IPC_OPERATION, IpcTransport } from "./ipcTransport";
 


### PR DESCRIPTION
This fixes the library, as without this the library is not usable.

Tested on Fedora 42 Linux aarch64 (Kernel 5.14.2)

Thanks.